### PR TITLE
Multi bus support

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ Please see the examples for normal operation. Below are the available functions 
  */
 TSYS01(TwoWire *wire = &Wire);
 
-/** Initialize the sensor - return false if not detected.
+/** Initialize the sensor connection - return false if not detected.
  */
 bool init();
 

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please see the examples for normal operation. Below are the available functions 
 
 ``` cpp
 /** Construct an instance of the sensor manager, with defined I2C bus connection details.
- *  Uses the default Wire bus if left unspecified (e.g. TSYS01()).
+ *  Uses the default Wire bus if left unspecified (e.g. "TSYS01 mySensor" is equivilent to "TSYS01 mySensor(&Wire)").
  */
 TSYS01(TwoWire *wire = &Wire);
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@ Arduino library for the TSYS01 temperature sensor. The TSYS01 is a high-accuracy
 Please see the examples for normal operation. Below are the available functions used in the library.
 
 ``` cpp
-/** Constructor - optional argument for specifying a different I2C bus (e.g. Wire1), will use Wire if not specified.
+/** Constructor - optional argument for specifying a different I2C bus (e.g. Wire1), 
+ *  will use Wire if not specified.
  */
 TSYS01(TwoWire *wire = &Wire);
 

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Please see the examples for normal operation. Below are the available functions 
 ``` cpp
 /** Construct an instance of the sensor manager, with defined I2C bus connection details.
  *  Uses the default Wire bus if left unspecified.
- *  (e.g. "TSYS01 mySensor" is equivilent to "TSYS01 mySensor(&Wire)")
+ *  (e.g. "TSYS01 mySensor;" is equivilent to "TSYS01 mySensor(&Wire);")
  */
 TSYS01(TwoWire *wire = &Wire);
 

--- a/README.md
+++ b/README.md
@@ -7,7 +7,9 @@ Arduino library for the TSYS01 temperature sensor. The TSYS01 is a high-accuracy
 Please see the examples for normal operation. Below are the available functions used in the library.
 
 ``` cpp
-TSYS01();
+/** Constructor - optional argument for specifying a different I2C bus (e.g. Wire1), will use Wire if not specified.
+ */
+TSYS01(TwoWire *wire = &Wire);
 
 /** Initialize the sensor - return false if not detected.
  */

--- a/README.md
+++ b/README.md
@@ -8,7 +8,8 @@ Please see the examples for normal operation. Below are the available functions 
 
 ``` cpp
 /** Construct an instance of the sensor manager, with defined I2C bus connection details.
- *  Uses the default Wire bus if left unspecified (e.g. "TSYS01 mySensor" is equivilent to "TSYS01 mySensor(&Wire)").
+ *  Uses the default Wire bus if left unspecified.
+ *  (e.g. "TSYS01 mySensor" is equivilent to "TSYS01 mySensor(&Wire)")
  */
 TSYS01(TwoWire *wire = &Wire);
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,7 @@ float temperature();
 
 # Versions
 
+- `1.0.2` - added support for different I2C busses
 - `1.0.1` - added initialization validation
 - `1.0.0` - initial release
 - `0.0` - Under development

--- a/README.md
+++ b/README.md
@@ -7,8 +7,8 @@ Arduino library for the TSYS01 temperature sensor. The TSYS01 is a high-accuracy
 Please see the examples for normal operation. Below are the available functions used in the library.
 
 ``` cpp
-/** Constructor - optional argument for specifying a different I2C bus (e.g. Wire1), 
- *  will use Wire if not specified.
+/** Construct an instance of the sensor manager, with defined I2C bus connection details.
+ *  Uses the default Wire bus if left unspecified (e.g. TSYS01()).
  */
 TSYS01(TwoWire *wire = &Wire);
 

--- a/TSYS01.cpp
+++ b/TSYS01.cpp
@@ -1,5 +1,4 @@
 #include "TSYS01.h"
-#include <Wire.h>
 
 #define TSYS01_ADDR                        0x77  
 #define TSYS01_RESET                       0x1E
@@ -7,26 +6,26 @@
 #define TSYS01_ADC_TEMP_CONV               0x48
 #define TSYS01_PROM_READ                   0XA0
 
-TSYS01::TSYS01() {
-
+TSYS01::TSYS01(TwoWire *wire) {
+	_wire = wire;
 }
 
 bool TSYS01::init() {
 	// Reset the TSYS01, per datasheet
-	Wire.beginTransmission(TSYS01_ADDR);
-	Wire.write(TSYS01_RESET);
-	Wire.endTransmission();
+	_wire->beginTransmission(TSYS01_ADDR);
+	_wire->write(TSYS01_RESET);
+	_wire->endTransmission();
 	
 	delay(10);
 	int received_bytes = 0;
 		// Read calibration values
 	for ( uint8_t i = 0 ; i < 8 ; i++ ) {
-		Wire.beginTransmission(TSYS01_ADDR);
-		Wire.write(TSYS01_PROM_READ+i*2);
-		Wire.endTransmission();
+		_wire->beginTransmission(TSYS01_ADDR);
+		_wire->write(TSYS01_PROM_READ+i*2);
+		_wire->endTransmission();
 
-		received_bytes += Wire.requestFrom(TSYS01_ADDR,2);
-		C[i] = (Wire.read() << 8) | Wire.read();
+		received_bytes += _wire->requestFrom(TSYS01_ADDR,2);
+		C[i] = (_wire->read() << 8) | _wire->read();
 	}
 	return received_bytes > 0;
 
@@ -34,21 +33,21 @@ bool TSYS01::init() {
 
 void TSYS01::read() {
 	
-	Wire.beginTransmission(TSYS01_ADDR);
-	Wire.write(TSYS01_ADC_TEMP_CONV);
-	Wire.endTransmission();
+	_wire->beginTransmission(TSYS01_ADDR);
+	_wire->write(TSYS01_ADC_TEMP_CONV);
+	_wire->endTransmission();
  
 	delay(10); // Max conversion time per datasheet
 	
-	Wire.beginTransmission(TSYS01_ADDR);
-	Wire.write(TSYS01_ADC_READ);
-	Wire.endTransmission();
+	_wire->beginTransmission(TSYS01_ADDR);
+	_wire->write(TSYS01_ADC_READ);
+	_wire->endTransmission();
 
-	Wire.requestFrom(TSYS01_ADDR,3);
+	_wire->requestFrom(TSYS01_ADDR,3);
 	D1 = 0;
-	D1 = Wire.read();
-	D1 = (D1 << 8) | Wire.read();
-	D1 = (D1 << 8) | Wire.read();
+	D1 = _wire->read();
+	D1 = (D1 << 8) | _wire->read();
+	D1 = (D1 << 8) | _wire->read();
 
 	calculate();
 }

--- a/TSYS01.h
+++ b/TSYS01.h
@@ -32,11 +32,12 @@ THE SOFTWARE.
 #define TSYS01_H_BLUEROBOTICS
 
 #include "Arduino.h"
+#include <Wire.h>
 
 class TSYS01 {
 public:
 
-	TSYS01();
+	TSYS01(TwoWire *wire = &Wire);
 
 	bool init();
 
@@ -55,6 +56,7 @@ public:
 	float temperature();
 
 private:
+	TwoWire*  _wire;
 	uint16_t C[8];
 	uint32_t D1;
 	float TEMP;

--- a/library.properties
+++ b/library.properties
@@ -1,5 +1,5 @@
 name=BlueRobotics TSYS01 Library
-version=1.0.1
+version=1.0.2
 author=BlueRobotics
 maintainer=BlueRobotics <info@bluerobotics.com>
 sentence=A simple and easy library for the TSYS01 temperature sensor


### PR DESCRIPTION
Adds support for using I2C busses other than the default Wire. Should be fully backwards compatible since the default constructor uses Wire.

Tested with hardware using Wire1, specifying Wire in constructor, and with default constructor with a Celsius and an Arduino nano R4